### PR TITLE
add setuptools dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -52,6 +52,7 @@ install_requires =
     boto3~=1.34.91
     botocore~=1.34.91
     requests-aws4auth~=1.2.3
+    setuptools~=72.1.0
 
 # Change this to False if you use things like __file__ or __path__—which you
 # shouldn't use anyway, because that's what ``pkg_resources`` is for 🙂


### PR DESCRIPTION
missing dep was breaking pip install from pypi

## 🗒️ Summary
`pip install pds.registry-client` did not result in working installation when tested on local environment.  Installation of `setuptools` was sufficient to fix.

## ⚙️ Test Data and/or Report
Manually tested that installation of `setuptools` resulted in working installation

## ♻️ Related Issues
fixes #3 
