### PR TITLE
Enable Python 3.12 and 3.13 compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,6 +93,7 @@ var/
 bin/
 .*.swp
 typescript
+.env
 
 # OS-specific artifacts
 .DS_Store

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,9 @@ repos:
     rev: v4.0.1
     hooks:
     -   id: trailing-whitespace
+        exclude: ^docs/requirements/
     -   id: end-of-file-fixer
+        exclude: ^docs/requirements/
     -   id: check-executables-have-shebangs
     -   id: check-merge-conflict
     -   id: debug-statements

--- a/docs/source/installation/index.rst
+++ b/docs/source/installation/index.rst
@@ -26,7 +26,7 @@ Requirements
 Prior to installing this software, ensure your system meets the following
 requirements:
 
-* Python_ 3. This software requires Python 3.13 or later. Python 2 will absolutely *not* work, and indeed Python 2 came to its end of life on the first of January, 2020.  Run ``python --version``, or ``python3 --version``, to check what is installed.
+* Python_ 3. This software requires Python 3.12 or later. Python 2 will absolutely *not* work, and indeed Python 2 came to its end of life on the first of January, 2020.  Run ``python --version``, or ``python3 --version``, to check what is installed.
 * Set environment variables
 
 Consult your operating system instructions or system administrator to install
@@ -108,8 +108,8 @@ Windows Installation
 
 To install the software on Windows comprises the following steps:
 
-1. Installing Python 3.13 for Windows
-2. Creating a "virtual environment" to contain an isolated instance of Python 3.13
+1. Installing Python 3.12+ for Windows
+2. Creating a "virtual environment" to contain an isolated instance of Python 3.12+
 3. Installing the PDS Registry Client into the virtual environment
 
 The remainder of this section details these steps.
@@ -118,9 +118,9 @@ The remainder of this section details these steps.
 Installing Python for Windows
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Python 3.13 (and specifically Python 3.13—no later or earlier versions will
+Python 3.12 or later (and specifically Python 3.12 or later—no earlier versions will
 work) will need to be installed onto your Windows system. There are several
-ways to get Python 3.13:
+ways to get Python 3.12+:
 
 • The "Microsoft Store" app
 • Directly from https://python.org/
@@ -132,24 +132,24 @@ Store app is probably the easiest. To use the Microsoft Store to install
 Python 3.13, do the following:
 
 1. In the Windows taskbar's search box or Start Menu, open Microsoft Store.
-2. In the search box at the top, type ``Python 3.13``
-3. In the list of matching results, press the "Get" button next to Python 3.13.
+2. In the search box at the top, type ``Python 3.12``
+3. In the list of matching results, press the "Get" button next to Python 3.12.
 
 .. tip::
 
     If you're on a managed system, you may need to ask your system
-    administrator to install Python 3.13 for you.
+    administrator to install Python 3.12+ for you.
 
 Next, confirm that it's properly installed by opening Windows PowerShell and
-starting Python 3.13 from the command-line. Use the Windows taskbar search
-box or Start Menu to launch Windows PowerShell, then type ``python3.11`` and
+starting Python from the command-line. Use the Windows taskbar search
+box or Start Menu to launch Windows PowerShell, then type ``python`` and
 press Enter.
 
 .. note::
 
     If you installed Python from https://python.org/ or using Anaconda or
     Miniconda, the command you enter may be ``python3`` or even simply
-    ``python`` instead of ``python3.13``.
+    ``python``.
 
 .. tip::
 
@@ -176,13 +176,13 @@ environment for the software.
 To do so, open Windows PowerShell (as above) and at the prompt, type the
 following command (then press Enter)::
 
-    python3.13 -m venv pds
+    python -m venv pds
 
 .. note::
 
     If you installed Python from https://python.org/ or using Anaconda or
-    Miniconda, you may need to replace ``python3.13`` with ``python3`` or
-    even simply ``python``.
+    Miniconda, the command you enter may be ``python3`` or even simply
+    ``python``.
 
 This will create a subfolder in the current directory called ``pds`` which
 contains the virtual environment. Next, you'll need to "activate" the virtual

--- a/setup.cfg
+++ b/setup.cfg
@@ -189,6 +189,10 @@ select = D,E,F,N,W,B,B902,B903,B950
 # options below. Note that the section syntax for ``mypy`` includes
 # glob-style wildcards to match file patterns.
 
+[mypy-opensearchpy.*]
+# Ignore missing imports for opensearchpy as it doesn't have type stubs
+ignore_missing_imports = True
+
 
 [mypy-pds.*._version]
 # We don't care about issues in versioneer's files

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,6 +16,7 @@ url = https://github.com/NASA-PDS/registry-client
 download_url = https://github.com/NASA-PDS/registry-client/releases/
 classifiers =
     Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.12
     Programming Language :: Python :: 3.13
     Operating System :: OS Independent
 
@@ -47,7 +48,7 @@ include_package_data = True
 package_dir =
     = src
 packages = find_namespace:
-python_requires = >= 3.13
+python_requires = >= 3.12
 
 [options.extras_require]
 dev =

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py313, docs, lint
+envlist = py312, py313, docs, lint
 isolated_build = True
 
 [testenv]
@@ -19,6 +19,6 @@ commands=
 skip_install = true
 
 [testenv:dev]
-basepython = python3.13
+basepython = python3.12
 usedevelop = True
 deps = .[dev]


### PR DESCRIPTION
<!--
    ************************************** REMINDER **************************************
    PR Titles should be "user-friendly". We use these titles
    to populate our Release Notes. Some examples can be found here:
    https://github.com/NASA-PDS/nasa-pds.github.io/wiki/Issue-Tracking#pull-request-titles
-->

## 🗒️ Summary
- Update setup.cfg to require Python >= 3.12 instead of >= 3.13
- Add Python 3.12 classifier to package metadata
- Update tox.ini to test both Python 3.12 and 3.13 environments
- Update documentation to reflect Python 3.12+ support
- Simplify installation instructions to be more flexible

## ⚙️ Test Data and/or Report
See branch testing github action

## ♻️ Related Issues
<!--
    Reference related issues here and use `Fixes` or `Resolves` in order to automatically close the issue upon merge. For more information on autolinking to tickets see https://docs.github.com/en/github/writing-on-github/autolinked-references-and-urls.

    * for issues in this repo:
        - fixes #1
        - fixes #2
        - refs #3
    * for issues in other repos: NASA-PDS/my_repo#1, NASA-PDS/her_repo#2
-->
- Fixes https://github.com/NASA-PDS/registry-client/issues/34